### PR TITLE
Improve Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,6 @@
 node_modules
+.git
+.github
+.gitignore
+*.md
+dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS base
+FROM node:20.5-alpine AS base
 
 # Default Variables
 ENV PUID=1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,57 @@
-FROM node:20.2-alpine AS base
-# Installs global dependencies as non root user for security
+FROM node:20-alpine AS base
+
+# Default Variables
+ENV PUID=1000
+ENV PGID=1000
+
+# Build time variables
+## Allow non-root usage
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH=$PATH:/home/node/.npm-global/bin
 
-# Uses environment variables from configuration.ts
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+
 ENV SERVER_TZ=UTC
 ENV SERVER_PORT=8080
-ENV VOLUMES_FILES="/files"
-ENV VOLUMES_IMAGES="/images"
-ENV VOLUMES_LOGS="/logs"
-ENV VOLUMES_SQLITEDB="/db"
+
+VOLUME /files /images /logs /db
 
 # Sets timezone, installs pnpm, creates and chowns the needed volumes for the node user
-RUN apk add --no-cache tzdata curl 7zip && cp /usr/share/zoneinfo/$SERVER_TZ /etc/localtime \
-    && npm i -g pnpm \
-    && mkdir /app $VOLUMES_FILES $VOLUMES_IMAGES $VOLUMES_LOGS $VOLUMES_SQLITEDB
+RUN apk add --no-cache su-exec tzdata curl 7zip \
+    && cp /usr/share/zoneinfo/$SERVER_TZ /etc/localtime \
+    && npm i -g pnpm
 
-# Copies the entire repository into the container
 WORKDIR /app
+
+FROM base AS build
+# Copy files only needed for install
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+# Copy everything for building
 COPY . .
+RUN pnpm run build
 
-#Installs Dependencies & Builds Server
-RUN pnpm install && pnpm build
+FROM base AS prod-deps
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --prod --frozen-lockfile
 
-# Permissions for node user
-RUN chown -R node:node /app $VOLUMES_FILES $VOLUMES_IMAGES $VOLUMES_LOGS $VOLUMES_SQLITEDB
+FROM base AS release
+ENV NODE_ENV=production
+COPY --from=build /app/dist ./dist
+COPY --from=prod-deps /app/node_modules ./node_modules
 
-# Uses non-root user to run the container
-USER node
-CMD [ "npm", "run", "start:prod" ]
-EXPOSE $SERVER_PORT
+# Chown /app to the original node user (1000)
+# As only read is needed this is fine when using --user or PUID
+RUN chown -R node:node /app
 
+# Entry script for providing dynamic env changes like PUID
+COPY entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+EXPOSE ${SERVER_PORT}/tcp
 # Periodic Healthcheck on /api/v1/health
-HEALTHCHECK CMD curl -f http://localhost:$SERVER_PORT/api/v1/health || exit
+HEALTHCHECK CMD curl -f http://localhost:${SERVER_PORT}/api/v1/health || exit
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD [ "dist/main" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,12 @@ ENV PATH=$PATH:/home/node/.npm-global/bin
 ENV PNPM_HOME=/pnpm
 ENV PATH=$PNPM_HOME:$PATH
 
-ENV SERVER_TZ=UTC
 ENV SERVER_PORT=8080
 
 VOLUME /files /images /logs /db
 
-# Sets timezone, installs pnpm, creates and chowns the needed volumes for the node user
+# Install pnpm and other needed tools
 RUN apk add --no-cache su-exec tzdata curl 7zip \
-    && cp /usr/share/zoneinfo/$SERVER_TZ /etc/localtime \
     && npm i -g pnpm
 
 WORKDIR /app

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+# If running as root, it means the --user directive for Docker CLI/Compose was not used
+# Use then the PUID env
+if [ "$(id -u)" = '0' ]; then
+    deluser node
+    addgroup -S node -g $PGID
+    adduser -S -G node -u $PUID node
+
+    exec su-exec "$PUID:$PGID" node "$@"
+else # if using the user directive, run normally
+    exec node "$@"
+fi


### PR DESCRIPTION
Now allows the system user to be specified via PUID/PGID and also via --user directive. Default is 1000 and --user takes precedence. `entrypoint.sh` handles it. Tested it with multiple IDs and with both variants.

Removed _VOLUME_* ENV vars, as they did not have any used as they are statically compiled into the Dockerimage. Also defined them as Docker **VOLUME** instead, which will automatically create an empty volume with a random id at the default Docker location IF a user does not specify a mount point for them in their compose. (Im not sure if I should do so the same with /files, as most will probably want to specify a mount point for that in all cases, but it does not really hurt).

This way we could also remove the image mountpoint in the docker compose in the docs or comment it out if the user wants to specify a specific location instead of the docker default.

Removed the chown to be compatible with `--user`; the user needs to make sure that if he specifies a mountpoint, that it has read or respectively write rights for the user.

Also introduced multi-stage build
