### PR TITLE
Add forced_sharp_version env variable to force a specific sharp version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN pnpm install && pnpm build
 
 # Uses non-root user to run the container
 USER node
-CMD [ "npm", "run", "start:prod" ]
+CMD /app/start.sh
 EXPOSE $SERVER_PORT
 
 # Periodic Healthcheck on /api/v1/health

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [[ ! -z "$forced_sharp_version" ]] ; then
+  echo "Forcing sharp version $forced_sharp_version"
+  pnpm install sharp@$forced_sharp_version
+fi
+
+pnpm run start:prod


### PR DESCRIPTION
sharp module requires libvips which needs cpus with AVX support, this PR add an env variable `forced_sharp_version` to force a sharp version
If the variable is set to a version number pnpm will attempt to install it before starting the application (the variable can be unset for later container starts).
This first version is quite abrupt, I'll see if I can improve by using the last possible version of sharp with a non avx compatible [libvips](https://github.com/lovell/sharp/issues/3743#issuecomment-1655601445).

Documentation PR for the new env variable will follow.



